### PR TITLE
Update suitesparse's find module scripts

### DIFF
--- a/library/src/cmake/suitesparse/FindCHOLMOD.cmake
+++ b/library/src/cmake/suitesparse/FindCHOLMOD.cmake
@@ -1,5 +1,5 @@
 # ########################################################################
-# Copyright (C) 2024 Advanced Micro Devices, Inc. All rights reserved.
+# Copyright (C) 2024-2025 Advanced Micro Devices, Inc. All rights reserved.
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -45,7 +45,10 @@ This module defines the following variables:
 
 #]=======================================================================]
 
-find_path(CHOLMOD_INCLUDE_DIR suitesparse/cholmod.h)
+find_path(CHOLMOD_INCLUDE_DIR
+    NAMES cholmod.h
+    PATH_SUFFIXES suitesparse
+    )
 find_library(CHOLMOD_LIBRARY cholmod)
 
 include(FindPackageHandleStandardArgs)

--- a/library/src/cmake/suitesparse/FindSuiteSparse_config.cmake
+++ b/library/src/cmake/suitesparse/FindSuiteSparse_config.cmake
@@ -1,5 +1,5 @@
 # ########################################################################
-# Copyright (C) 2024 Advanced Micro Devices, Inc. All rights reserved.
+# Copyright (C) 2024-2025 Advanced Micro Devices, Inc. All rights reserved.
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -45,7 +45,10 @@ This module defines the following variables:
 
 #]=======================================================================]
 
-find_path(SUITESPARSE_CONFIG_INCLUDE_DIR suitesparse/SuiteSparse_config.h)
+find_path(SUITESPARSE_CONFIG_INCLUDE_DIR
+    NAMES SuiteSparse_config.h
+    PATH_SUFFIXES suitesparse
+    )
 find_library(SUITESPARSE_CONFIG_LIBRARY suitesparseconfig)
 
 include(FindPackageHandleStandardArgs)


### PR DESCRIPTION
hipSOLVER's find module scripts (for suitesparse) were using `find_path` on name `suitesparse/cholmod.h` instead of `cholmod.h`, which allowed hipSOLVER to `#include <suitesparse/cholmod.h>`.

This commit updates the aforementioned cmake scripts, to honour the way `Suitesparse::CHOLMOD` advertises its include directories.